### PR TITLE
Added script for Slack notification upon code sync.

### DIFF
--- a/slack_notification/slack_deploy_notification.php
+++ b/slack_notification/slack_deploy_notification.php
@@ -1,0 +1,40 @@
+<?php
+// Find out what tag we are on and get the annotation.
+$deploy_tag = `git describe --tags`;
+$annotation = `git tag -l -n99 $deploy_tag`;
+// Load our hidden credentials.
+// See the README.md for instructions on storing secrets.
+$secrets = json_decode(file_get_contents($_SERVER['HOME'] . '/files/private/secrets.json'), 1);
+if ($secrets == FALSE) {
+  die('No secrets file found. Aborting!');
+}
+
+isset ($secrets['slack_channel']) ? $channel = $secrets['slack_channel'] : $channel = '#quicksilver';
+
+// Prepare the slack payload as per:
+// https://api.slack.com/incoming-webhooks
+// TODO: use awesome attachment-style formatting.
+// https://api.slack.com/docs/attachments
+$text = 'Deploy to the '. $_ENV['PANTHEON_ENVIRONMENT'];
+$text .= ' environment of '. $_ENV['PANTHEON_SITE_NAME'] .' by '. $_POST['user_email'] .' complete!';
+$text .= ' <https://dashboard.pantheon.io/sites/'. PANTHEON_SITE .'#'. PANTHEON_ENVIRONMENT .'/deploys|View Dashboard>';
+$text .= "\n\n*DEPLOY MESSAGE*: $annotation";
+$post = array(
+  'username' => 'Pantheon-Quicksilver',
+  'text' => $text,
+  'channel' => $channel,
+  'icon_emoji' => ':lightning_cloud:'
+);
+$payload = json_encode($post);
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $secrets['slack_url']);
+curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+print("\n==== Posting to Slack ====\n");
+$result = curl_exec($ch);
+print("RESULT: $result");
+print("\n===== Post Complete! =====\n");
+curl_close($ch);


### PR DESCRIPTION
This adds a script to send the most recent commit to Slack upon code sync, and makes some minor formatting improvements to the original slack_notification.php (now renamed to slack_deploy_notification.php). It also pulls the Slack channel from a slack_channel key in secrets.json, if it exists. This removes all site-specific code from the script, enabling it to be included in an organization's upstream.