### PR TITLE
Slack Attachments & Debugging for better construction of JSON Slack Webhooks

### DIFF
--- a/slack_notification/slack_deploy_notification.php
+++ b/slack_notification/slack_deploy_notification.php
@@ -28,7 +28,7 @@ $fields = array(
   ),
   array( // Render Environment name with link to site, <http://{ENV}-{SITENAME}.pantheon.io|{ENV}>
     'title' => 'Environment',
-    'value' => '<http://' . $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . 'pantheon.io|' . $_ENV['PANTHEON_ENVIRONMENT'] . '>',
+    'value' => '<http://' . $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . '.pantheon.io|' . $_ENV['PANTHEON_ENVIRONMENT'] . '>',
     'short' => 'true'
   ),
   array( // Render Name with link to Email from Commit message

--- a/slack_notification/slack_deploy_notification.php
+++ b/slack_notification/slack_deploy_notification.php
@@ -13,17 +13,52 @@ isset ($secrets['slack_channel']) ? $channel = $secrets['slack_channel'] : $chan
 
 // Prepare the slack payload as per:
 // https://api.slack.com/incoming-webhooks
-// TODO: use awesome attachment-style formatting.
-// https://api.slack.com/docs/attachments
 $text = 'Deploy to the '. $_ENV['PANTHEON_ENVIRONMENT'];
 $text .= ' environment of '. $_ENV['PANTHEON_SITE_NAME'] .' by '. $_POST['user_email'] .' complete!';
 $text .= ' <https://dashboard.pantheon.io/sites/'. PANTHEON_SITE .'#'. PANTHEON_ENVIRONMENT .'/deploys|View Dashboard>';
 $text .= "\n\n*DEPLOY MESSAGE*: $annotation";
+// Build an array of fields to be rendered with Slack Attachments as a table
+// attachment-style formatting:
+// https://api.slack.com/docs/attachments
+$fields = array(
+  array(
+    'title' => 'Site',
+    'value' => $_ENV['PANTHEON_SITE_NAME'],
+    'short' => 'true'
+  ),
+  array( // Render Environment name with link to site, <http://{ENV}-{SITENAME}.pantheon.io|{ENV}>
+    'title' => 'Environment',
+    'value' => '<http://' . $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . 'pantheon.io|' . $_ENV['PANTHEON_ENVIRONMENT'] . '>',
+    'short' => 'true'
+  ),
+  array( // Render Name with link to Email from Commit message
+    'title' => 'By',
+    'value' => $_POST['user_email'],
+    'short' => 'true'
+  ),
+  array(
+    'title' => 'View Dashboard',
+    'value' => '<https://dashboard.pantheon.io/sites/'. PANTHEON_SITE .'#'. PANTHEON_ENVIRONMENT .'/deploys|View Dashboard>',
+    'short' => 'true'
+  ),
+  array(
+    'title' => 'Deploy Message',
+    'value' => $annotation,
+    'short' => 'false'
+  )
+);
+$attachment = array(
+  'fallback' => $text,
+  'pretext' => 'Deploying :rocket:',
+  'color' => '#EFD01B', // Can either be one of 'good', 'warning', 'danger', or any hex color code, but this is Pantheon Yellow
+  'fields' => $fields
+);
 $post = array(
   'username' => 'Pantheon-Quicksilver',
-  'text' => $text,
+  // 'text' => $text, // Uncomment if you always want to send a text message, otherwise display attachment->fallback when needed
   'channel' => $channel,
-  'icon_emoji' => ':lightning_cloud:'
+  'icon_emoji' => ':lightning_cloud:',
+  'attachments' => array($attachment)
 );
 $payload = json_encode($post);
 $ch = curl_init();
@@ -33,8 +68,11 @@ curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_TIMEOUT, 5);
 curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
 curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+// Watch for messages with `terminus workflows watch --site=SITENAME`
 print("\n==== Posting to Slack ====\n");
 $result = curl_exec($ch);
 print("RESULT: $result");
+// $payload_pretty = json_encode($post,JSON_PRETTY_PRINT); // Uncomment to debug JSON
+// print("JSON: $payload_pretty"); // Uncomment to Debug JSON
 print("\n===== Post Complete! =====\n");
 curl_close($ch);

--- a/slack_notification/slack_sync_notification.php
+++ b/slack_notification/slack_sync_notification.php
@@ -27,7 +27,7 @@ $fields = array(
   ),
   array( // Render Environment name with link to site, <http://{ENV}-{SITENAME}.pantheon.io|{ENV}>
     'title' => 'Environment',
-    'value' => '<http://' . $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . 'pantheon.io|' . $_ENV['PANTHEON_ENVIRONMENT'] . '>',
+    'value' => '<http://' . $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . '.pantheon.io|' . $_ENV['PANTHEON_ENVIRONMENT'] . '>',
     'short' => 'true'
   ),
   array( // Render Name with link to Email from Commit message

--- a/slack_notification/slack_sync_notification.php
+++ b/slack_notification/slack_sync_notification.php
@@ -14,15 +14,50 @@ isset ($secrets['slack_channel']) ? $channel = $secrets['slack_channel'] : $chan
 
 // Prepare the slack payload as per:
 // https://api.slack.com/incoming-webhooks
-// TODO: use awesome attachment-style formatting.
-// https://api.slack.com/docs/attachments
 $text = 'Code sync to the ' . $_ENV['PANTHEON_ENVIRONMENT'] . ' environment of ' . $_ENV['PANTHEON_SITE_NAME'] . ' by ' . $_POST['user_email'] . "!\n";
 $text .= 'Most recent commit: ' . rtrim($hash) . ' by ' . rtrim($committer) . ': ' . $message;
+// Build an array of fields to be rendered with Slack Attachments as a table
+// attachment-style formatting:
+// https://api.slack.com/docs/attachments
+$fields = array(
+  array(
+    'title' => 'Site',
+    'value' => $_ENV['PANTHEON_SITE_NAME'],
+    'short' => 'true'
+  ),
+  array( // Render Environment name with link to site, <http://{ENV}-{SITENAME}.pantheon.io|{ENV}>
+    'title' => 'Environment',
+    'value' => '<http://' . $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . 'pantheon.io|' . $_ENV['PANTHEON_ENVIRONMENT'] . '>',
+    'short' => 'true'
+  ),
+  array( // Render Name with link to Email from Commit message
+    'title' => 'By',
+    'value' => '<mailto:' . $_POST['user_email'] . '|' . rtrim($committer) . '>',
+    'short' => 'true'
+  ),
+  array(
+    'title' => 'Commit',
+    'value' => rtrim($hash),
+    'short' => 'true'
+  ),
+  array(
+    'title' => 'Commit Message',
+    'value' => $message,
+    'short' => 'false'
+  )
+);
+$attachment = array(
+  'fallback' => $text,
+  'pretext' => 'Code syncing :space_invader:',
+  'color' => '#EFD01B', // Can either be one of 'good', 'warning', 'danger', or any hex color code, but this is Pantheon Yellow
+  'fields' => $fields
+);
 $post = array(
   'username' => 'Pantheon-Quicksilver',
-  'text' => $text,
+  // 'text' => $text, // Uncomment if you always want to send a text message, otherwise display attachment->fallback when needed
   'channel' => $channel,
-  'icon_emoji' => ':lightning_cloud:'
+  'icon_emoji' => ':lightning_cloud:',
+  'attachments' => array($attachment)
 );
 $payload = json_encode($post);
 $ch = curl_init();
@@ -32,8 +67,11 @@ curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_TIMEOUT, 5);
 curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
 curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+// Watch for messages with `terminus workflows watch --site=SITENAME`
 print("\n==== Posting to Slack ====\n");
 $result = curl_exec($ch);
 print("RESULT: $result");
+// $payload_pretty = json_encode($post,JSON_PRETTY_PRINT); // Uncomment to debug JSON
+// print("JSON: $payload_pretty"); // Uncomment to Debug JSON
 print("\n===== Post Complete! =====\n");
 curl_close($ch);


### PR DESCRIPTION
Converted the example slack deploy and code push notifications to Slack attachments.
Added some lines to make debugging the attachments payload much easier. 

This is a very specific example that I think will work well for 80% of people, but there are more options you could include in slack attachments if you want to build out the example.