### PR TITLE
Drush example

### DIFF
--- a/drush_example/README.md
+++ b/drush_example/README.md
@@ -11,6 +11,8 @@ The demonstration enables the [devel](https://www.drupal.org/project/devel) modu
 - Add a Quicksilver operation to your pantheon.yml to fire the script after a `clone_database`.
 - Test a database clone to dev from an environment where the devel module is not enabled.
 
+Note: While Pantheon does not require a `settings.php` file to run Drupal, Drush does. Make sure you have one committed to the codebase.
+
 ### Example `pantheon.yml` ###
 
 Here's an example of what your `pantheon.yml` would look like if this were the only Quicksilver operation you wanted to use:

--- a/drush_example/README.md
+++ b/drush_example/README.md
@@ -1,0 +1,27 @@
+# Drush Example #
+
+This script demonstrates how to use drush from within a Quicksilver script.
+
+The demonstration enables the [devel](https://www.drupal.org/project/devel) module after a database has been cloned to the `dev` environment.
+
+## Instructions ##
+
+- Be sure the [devel](https://www.drupal.org/project/devel) module is installed into your Drupal codebase.
+- Copy `drush_example` directory to the private/scripts directory of your code repository.
+- Add a Quicksilver operation to your pantheon.yml to fire the script after a clone_database.
+- Test a database clone to dev from an environment where the devel module is not enabled.
+
+### Example `pantheon.yml` ###
+
+Here's an example of what your `pantheon.yml` would look like if this were the only Quicksilver operation you wanted to use:
+
+```yaml
+api_version: 1
+
+workflows:
+  clone_database:
+    after:
+      - type: webphp
+        description: Drush Example
+        script: private/scripts/drush_example/drush_example.php
+```

--- a/drush_example/README.md
+++ b/drush_example/README.md
@@ -7,8 +7,8 @@ The demonstration enables the [devel](https://www.drupal.org/project/devel) modu
 ## Instructions ##
 
 - Be sure the [devel](https://www.drupal.org/project/devel) module is installed into your Drupal codebase.
-- Copy `drush_example` directory to the private/scripts directory of your code repository.
-- Add a Quicksilver operation to your pantheon.yml to fire the script after a clone_database.
+- Copy the `drush_example` directory into the private/scripts directory of your code repository.
+- Add a Quicksilver operation to your pantheon.yml to fire the script after a `clone_database`.
 - Test a database clone to dev from an environment where the devel module is not enabled.
 
 ### Example `pantheon.yml` ###

--- a/drush_example/drush_example.php
+++ b/drush_example/drush_example.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This example enables the devel module when a database is cloned to the dev environment.
+ *
+ * This script should be configured into the clone_database operation in pantheon.yml
+ */
+
+// The clone_database may be triggered on any environment, but we only want
+// to automatically enable the devel module when this event happens on dev.
+if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT == 'dev')) {
+  // First, let's retrieve a list of disabled modules with drush pm-list.
+  // shell_exec() will return the output of an executable as a string.
+  // Pass the --format=json flag into the drush command so the output can be converted into an array with json_decode().
+  $disabled_modules = json_decode(shell_exec('drush drush pm-list --status=disabled --format=json'));
+
+  // Now let's enable devel if it is disabled.
+  if ($disabled_modules['devel']) {
+    // This time let's just passthru() on the drush command so the output prints to the workflow output
+    passthru('drush pm-disable -y devel');
+  }
+}

--- a/drush_example/drush_example.php
+++ b/drush_example/drush_example.php
@@ -7,15 +7,15 @@
 
 // The clone_database may be triggered on any environment, but we only want
 // to automatically enable the devel module when this event happens on dev.
-if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT == 'dev')) {
+if (defined('PANTHEON_ENVIRONMENT') && PANTHEON_ENVIRONMENT == 'dev') {
   // First, let's retrieve a list of disabled modules with drush pm-list.
   // shell_exec() will return the output of an executable as a string.
   // Pass the --format=json flag into the drush command so the output can be converted into an array with json_decode().
-  $disabled_modules = json_decode(shell_exec('drush drush pm-list --status=disabled --format=json'));
+  $modules = json_decode(shell_exec('drush pm-list --format=json'));
 
-  // Now let's enable devel if it is disabled.
-  if ($disabled_modules['devel']) {
-    // This time let's just passthru() on the drush command so the output prints to the workflow output
-    passthru('drush pm-disable -y devel');
+  // Now let's enable devel if it is installed and not already enabled.
+  if (isset($modules->devel) && $modules->devel->status !== 'Enabled') {
+    // This time let's just passthru() to run the drush command so the command output prints to the workflow log.
+    passthru('drush pm-enable -y devel');
   }
 }


### PR DESCRIPTION
An example that shows drush executed with `shell_exec()` in conjunction with `--format=json` on the drush command, as well as a simple `passthru()`.