### PR TITLE
Hipchat notification

### DIFF
--- a/hipchat_notification/README.md
+++ b/hipchat_notification/README.md
@@ -7,10 +7,10 @@ This script shows how easy it is to integrate Hipchat notifications from your Pa
 Setting up this example is easy:
 
 - Within the Hipchat administration area, create an auth token with the `Send Notification` permission. (Rooms -> RoomID -> Tokens)
-- Copy the secret token into a file called `secrets.json` and store it in the private files area of your site
+- Copy the secret token and room id into a file called `secrets.json` and store it in the private files area of your site
 
 ```shell
-  $> echo '{"hipchat_auth_token": "a5boORCcbLnqW4kpa71Os37aPZsnc9EXkGDwY0GE"}' > secrets.json
+  $> echo '{"hipchat_room_id": "DevChat", "hipchat_auth_token": "a5boORCcbLnqW4kpa71Os37aPZsnc9EXkGDwY0GE"}' > secrets.json
   # Note, you'll need to copy the secrets into each environment where you want to trigger Hipchat notifications.
   $> `terminus site connection-info --env=dev --site=your-site --field=sftp_command`
       Connected to appserver.dev.d1ef01f8-364c-4b91-a8e4-f2a46f14237e.drush.in.
@@ -21,8 +21,8 @@ Setting up this example is easy:
 ```
 
 - Add the example `hipchat_notification` directory to the `private/scripts` directory of your code repository.
-- Add the Quicksilver operations to your `pantheon.yml` to fire the script a deploy.
-- Test a deploy out!
+- Add the Quicksilver operations to your `pantheon.yml` to fire the scripts when code is synced and deployed.
+- Test out a code commit and deployment while watching your Hipchat channel!
 
 Optionally, you may want to use the `terminus workflows watch` command to get immediate debugging feedback. You may also want to customize your notifications further. The [Slack API](https://api.slack.com/incoming-webhooks) documentation has more on your options.
 

--- a/hipchat_notification/README.md
+++ b/hipchat_notification/README.md
@@ -1,0 +1,48 @@
+# Hipchat Integration #
+
+This script shows how easy it is to integrate Hipchat notifications from your Pantheon project using Quicksilver. As a bonus, we also show you how to manage API keys outside of your site repository.
+
+## Instructions ##
+
+Setting up this example is easy:
+
+- Within the Hipchat administration area, create an auth token with the `Send Notification` permission. (Rooms -> RoomID -> Tokens)
+- Copy the secret token into a file called `secrets.json` and store it in the private files area of your site
+
+```shell
+  $> echo '{"hipchat_auth_token": "a5boORCcbLnqW4kpa71Os37aPZsnc9EXkGDwY0GE"}' > secrets.json
+  # Note, you'll need to copy the secrets into each environment where you want to trigger Hipchat notifications.
+  $> `terminus site connection-info --env=dev --site=your-site --field=sftp_command`
+      Connected to appserver.dev.d1ef01f8-364c-4b91-a8e4-f2a46f14237e.drush.in.
+  sftp> cd files
+  sftp> mkdir private
+  sftp> cd private
+  sftp> put secrets.json
+```
+
+- Add the example `hipchat_notification` directory to the `private/scripts` directory of your code repository.
+- Add the Quicksilver operations to your `pantheon.yml` to fire the script a deploy.
+- Test a deploy out!
+
+Optionally, you may want to use the `terminus workflows watch` command to get immediate debugging feedback. You may also want to customize your notifications further. The [Slack API](https://api.slack.com/incoming-webhooks) documentation has more on your options.
+
+### Example `pantheon.yml` ###
+
+Here's an example of what your `pantheon.yml` would look like if these were the only Quicksilver operations you wanted to use:
+
+```yaml
+api_version: 1
+
+workflows:
+  deploy:
+    after:
+      - type: webphp
+        description: Hipchat Notification - Deploy
+        script: private/scripts/hipchat_notification/hipchat_notification_deploy.php
+  sync_code:
+    after:
+      - type: webphp
+        description: Hipchat Notification - Sync
+        script: private/scripts/hipchat_notification/hipchat_notification_sync.php
+```
+

--- a/hipchat_notification/hipchat_notification.inc
+++ b/hipchat_notification/hipchat_notification.inc
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Get secrets from secrets file.
+ *
+ * @param array $required_keys  List of keys in secrets file that must exist.
+ */
+function hipchat_notification_get_secrets($required_keys, $defaults) {
+  $secrets_file = $_SERVER['HOME'] . '/files/private/secrets.json';
+  if (!file_exists($secrets_file)) {
+    print $secrets_file . "\n";
+    die('No secrets file found. Aborting!');
+  }
+  $secrets_contents = file_get_contents($secrets_file);
+  $secrets = json_decode($secrets_contents, 1);
+  if ($secrets == FALSE) {
+    die('Could not parse json in secrets file. Aborting!');
+  }
+  $secrets += $defaults;
+  $missing = array_diff($required_keys, array_keys($secrets));
+  if (!empty($missing)) {
+    die('Missing required keys in json secrets file: ' . implode(',', $missing) . '. Aborting!');
+  }
+  return $secrets;
+}
+
+/**
+ * Send a notification to hipchat
+ */
+function hipchat_notification_send($room_id, $auth_token, $text) {
+  $data = array('color' => 'yellow', 'message' => $text);
+  $payload = json_encode($data);
+  $ch = curl_init();
+  curl_setopt($ch, CURLOPT_URL, 'https://api.hipchat.com/v2/room/' . $room_id . '/notification');
+  curl_setopt($ch, CURLOPT_POST, 1);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+  curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+  curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+    'Content-Type: application/json',
+    'Authorization: Bearer ' . $auth_token
+  ));
+  curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+
+  // Uncomment this section for debug
+  /*
+  print("\n==== Begin Debug Data ====\n");
+  print "Room ID: " . $room_id . "\n";
+  print "Auth Token: " . $auth_token . "\n";
+  print "Payload: \n";
+  print_r($data);
+  print("\n==== End Debug Data ====\n");
+  */
+
+  // Watch for messages with `terminus workflows watch --site=SITENAME`
+  print("\n==== Posting to Hipchat ====\n");
+  $result = curl_exec($ch);
+  print("RESULT: $result");
+  print("\n===== Post Complete! =====\n");
+  curl_close($ch);
+}

--- a/hipchat_notification/hipchat_notification_deploy.php
+++ b/hipchat_notification/hipchat_notification_deploy.php
@@ -1,0 +1,25 @@
+<?php
+
+require __DIR__ . '/hipchat_notification.inc';
+
+// Find out what tag we are on and get the annotation.
+$deploy_tag = `git describe --tags`;
+$annotation = str_replace(" ''", '', `git tag -l -n99 $deploy_tag`);
+
+// Default values for parameters
+$defaults = array(
+  'hipchat_room_id' => 'quicksilver'
+);
+
+// Load our hidden credentials.
+// See the README.md for instructions on storing secrets.
+$secrets = hipchat_notification_get_secrets(array('hipchat_auth_token'), $defaults);
+
+// Prepare the message
+$url = 'https://dashboard.pantheon.io/sites/'. PANTHEON_SITE .'#'. PANTHEON_ENVIRONMENT .'/deploy';
+$text = '<b>' . $_POST['user_fullname'] . '</b> deployed
+<a href="' . $url . '">' . $_ENV['PANTHEON_SITE_NAME'] . '</a><br />
+<b>On branch "' . PANTHEON_ENVIRONMENT . '"</b><br />
+Deploy Message: ' . htmlentities($annotation);
+
+hipchat_notification_send($secrets['hipchat_room_id'], $secrets['hipchat_auth_token'], $text);

--- a/hipchat_notification/hipchat_notification_sync.php
+++ b/hipchat_notification/hipchat_notification_sync.php
@@ -1,0 +1,25 @@
+<?php
+
+require __DIR__ . '/hipchat_notification.inc';
+
+// Get the hash and message of the most recent commit.
+$message = `git log -1 --pretty=%B`;
+$hash = trim(`git log -1 --pretty=%h`);
+
+// Default values for parameters
+$defaults = array(
+  'hipchat_room_id' => 'quicksilver'
+);
+
+// Load our hidden credentials.
+// See the README.md for instructions on storing secrets.
+$secrets = hipchat_notification_get_secrets(array('hipchat_auth_token'), $defaults);
+
+// Prepare the message
+$url = 'https://dashboard.pantheon.io/sites/'. PANTHEON_SITE .'#'. PANTHEON_ENVIRONMENT .'/code';
+$text = '<b>' . $_POST['user_fullname'] . '</b> committed to
+<a href="' . $url . '">' . $_ENV['PANTHEON_SITE_NAME'] . '</a><br />
+<b>On branch "' . PANTHEON_ENVIRONMENT . '"</b><br />
+- ' . htmlentities($message) . ' (<a href="' . $url . '">' . $hash . '</a>)';
+
+hipchat_notification_send($secrets['hipchat_room_id'], $secrets['hipchat_auth_token'], $text);


### PR DESCRIPTION
Similar to the slack_notification example, but for hipchat. I formatted the messages to look more like the default Atlassian integrations for their repo products and hipchat.

![hipchat_notification](https://cloud.githubusercontent.com/assets/1287855/12667650/490b3f0c-c603-11e5-9afd-57c7b712200a.png)

Note: the `Ansible` text in the screenshot comes from the token name on the hipchat side, not this example itself. Just an existing token I was testing with.
