### PR TITLE
Show environment variables in the debugging example

### DIFF
--- a/debugging_example/debug.php
+++ b/debugging_example/debug.php
@@ -5,3 +5,7 @@ echo "\n\n";
 echo "\n========= START PAYLOAD ===========\n";
 print_r($_POST);
 echo "\n========== END PAYLOAD ============\n";
+
+echo "\n------- START ENVIRONMENT ---------\n";
+passthru("printenv");
+echo "\n-------- END ENVIRONMENT ----------\n";

--- a/debugging_example/debug.php
+++ b/debugging_example/debug.php
@@ -7,5 +7,8 @@ print_r($_POST);
 echo "\n========== END PAYLOAD ============\n";
 
 echo "\n------- START ENVIRONMENT ---------\n";
-passthru("printenv");
+$env = $_ENV;
+unset($env['DB_PASSWORD']);
+unset($env['DRUPAL_HASH_SALT']);
+print_r($env);
 echo "\n-------- END ENVIRONMENT ----------\n";

--- a/debugging_example/debug.php
+++ b/debugging_example/debug.php
@@ -9,7 +9,7 @@ echo "\n========== END PAYLOAD ============\n";
 echo "\n------- START ENVIRONMENT ---------\n";
 $env = $_ENV;
 foreach ($env as $key => $value) {
-  if (preg_match('#(PASSWORD|SALT)#', $key)) {
+  if (preg_match('#(PASSWORD|SALT|AUTH|SECURE|NONCE|LOGGED_IN)#', $key)) {
     $env[$key] = '[REDACTED]';
   }
 }

--- a/debugging_example/debug.php
+++ b/debugging_example/debug.php
@@ -8,7 +8,10 @@ echo "\n========== END PAYLOAD ============\n";
 
 echo "\n------- START ENVIRONMENT ---------\n";
 $env = $_ENV;
-unset($env['DB_PASSWORD']);
-unset($env['DRUPAL_HASH_SALT']);
+foreach ($env as $key => $value) {
+  if (preg_match('#(PASSWORD|SALT)#', $key)) {
+    $env[$key] = '[REDACTED]';
+  }
+}
 print_r($env);
 echo "\n-------- END ENVIRONMENT ----------\n";


### PR DESCRIPTION
I like to show the environment variables in my debugging scripts.  Any reason why we shouldn't do this in the example?