### PR TITLE
Example of automatically importing settings for wordpress

### DIFF
--- a/wp_cfm_import/README.md
+++ b/wp_cfm_import/README.md
@@ -1,0 +1,65 @@
+# Automatically importing wp-cfm settings after cloning a database
+
+A common need is for development environments to have slightly different settings than the production environment.
+
+For example, you my have different configurations for third-party plugins, like google analytics property ids.  Or, you
+may want to turn off some plugins in development that aren't needed.
+
+A good way to manage different configurations is by using the [WP-CFM plugin](https://wordpress.org/plugins/wp-cfm/), but
+unless you can apply the configurations automatically, you will have to remember to apply them everytime you clone a database
+from your production environment.  Fortunately, Quicksilver gives us the opportunity to automate that.
+
+This example will show you how you can automatically apply configurations to your database from WP-CFM configuration files
+stored in git.
+ 
+## Instructions
+
+### Hiding configuration files
+
+By default WP-CFM looks for it's configuration files in `/config`, relative to the document root of your site.  That's
+not a great example on Pantheon, because it will be publically browsable. Instead, it would be better to store the files
+in `/private/config`.  To do this:
+
+1. Install the wp-cfm from the master branch on [Github](https://github.com/forumone/wp-cfm).  The
+   plugin in the WordPress repository has not been updated with the ability to change locations.
+2. Add a mu-plugin to your site to set the wp-cfm directory paths early in the WordPress loading process.  An example mu-plugin
+   included in the file `alter_wpcfm_config_path.php` in this repo.  Just copy it to `wp-config/mu-plugins`.
+   
+### Creating a WP-CFM configuration file
+
+This should be straight forward, but you need to know which _wp_options_ values you should track.  If you don't know, one way to
+find out is this:
+
+1. Put your site into sftp mode.
+1. Clone your database from the live environment.
+2. Create a temporary wp-cfm bundle tracking all the options and push it to the filesystem.
+3. Make the changes you want to see in your development site.
+4. Use the _diff_ functionality to compare the saved bundle with the current state of the database.
+5. The options that have changed are the ones you should track.
+6. Re-clone the database from the live environment.
+7. Make the changes you want again.
+8. Make a new bundle, and track only the options you identified.
+9. Push the bundle to the filesystem.
+10. Delete the temporary wp-cfm bundle you created.
+11. Put your site back into git mode, making sure the new bundle gets saved.
+
+### Automating loading the WP-CFM configuration file
+
+You can have as many or as few configurations as you like.  In `wp_cfm_after_clone.php` change the values in `$config_map` to
+set the mapping between environments and filenames.  Follow the instructions in the comments.
+
+Now we just need to configure our pantheon.yml to actually do the import, triggered after the `db_clone` workflow:
+
+```
+---
+api_version: 1
+
+workflows:
+
+  # Database Clones: Notify, sanitize, and notify on db clone
+  clone_database:
+    after:
+      - type: webphp
+        description: Pull environment specific config using wp-cfm after cloning db
+        script: private/scripts/wp_cfm_after_clone.php
+```

--- a/wp_cfm_import/README.md
+++ b/wp_cfm_import/README.md
@@ -34,17 +34,14 @@ This should be straight forward, but you need to know which _wp_options_ values 
 find out is this:
 
 1. Put your site into sftp mode.
-1. Clone your database from the live environment.
-2. Create a temporary wp-cfm bundle tracking all the options and push it to the filesystem.
-3. Make the changes you want to see in your development site.
-4. Use the _diff_ functionality to compare the saved bundle with the current state of the database.
-5. The options that have changed are the ones you should track.
-6. Re-clone the database from the live environment.
-7. Make the changes you want again.
-8. Make a new bundle, and track only the options you identified.
-9. Push the bundle to the filesystem.
-10. Delete the temporary wp-cfm bundle you created.
-11. Put your site back into git mode, making sure the new bundle gets saved.
+2. Clone your database from the live environment.
+3. Create a wp-cfm bundle, tracking all the options, and push it to the filesystem.
+4. Make the changes you want to see in your development site.
+5. Use the diff functionality to compare the saved bundle with the current state of the database.
+6. Update the wp-cfm bundle to track only the options that changed in step 5.
+7. Push the bundle to the filesystem.
+8. Commit the new bundle files in the Pantheon dashboard.
+9. Put your site back into git mode.
 
 ### Automating loading the WP-CFM configuration file
 

--- a/wp_cfm_import/README.md
+++ b/wp_cfm_import/README.md
@@ -14,16 +14,19 @@ stored in git.
  
 ## Instructions
 
+### Install WP-CFM
+
+Install the wp-cfm plugin from the master branch on [Github](https://github.com/forumone/wp-cfm).  (We need to use the
+master branch here, because it allows us to set the configuration file locations - this functionality isn't in the
+code on wordpress.org yet).
+
 ### Hiding configuration files
 
 By default WP-CFM looks for it's configuration files in `/config`, relative to the document root of your site.  That's
 not a great example on Pantheon, because it will be publically browsable. Instead, it would be better to store the files
-in `/private/config`.  To do this:
-
-1. Install the wp-cfm from the master branch on [Github](https://github.com/forumone/wp-cfm).  The
-   plugin in the WordPress repository has not been updated with the ability to change locations.
-2. Add a mu-plugin to your site to set the wp-cfm directory paths early in the WordPress loading process.  An example mu-plugin
-   included in the file `alter_wpcfm_config_path.php` in this repo.  Just copy it to `wp-config/mu-plugins`.
+in `/private/config`.  To do this, add a mu-plugin to your site to set the wp-cfm directory paths early in the 
+WordPress loading process.  An example mu-plugin is included in the file `alter_wpcfm_config_path.php` in this repo.  
+Just copy it to `wp-config/mu-plugins`.
    
 ### Creating a WP-CFM configuration file
 

--- a/wp_cfm_import/README.md
+++ b/wp_cfm_import/README.md
@@ -16,9 +16,7 @@ stored in git.
 
 ### Install WP-CFM
 
-Install the wp-cfm plugin from the master branch on [Github](https://github.com/forumone/wp-cfm).  (We need to use the
-master branch here, because it allows us to set the configuration file locations - this functionality isn't in the
-code on wordpress.org yet).
+Install the [wp-cfm plugin](https://wordpress.org/plugins/wp-cfm/) in the usual way.
 
 ### Hiding configuration files
 

--- a/wp_cfm_import/alter_wpcfm_config_path.php
+++ b/wp_cfm_import/alter_wpcfm_config_path.php
@@ -1,0 +1,13 @@
+<?php
+/*
+  Plugin Name: Alter-wpcfm-config-path 
+  Plugin URI: http://www.eyesopen.ca
+  Description: Alters the wpcfm config path 
+  Version: 0.1
+  Author: Grant McInnes 
+  Author URI: http://www.eyesopen.ca
+*/
+
+// Tell wp-cfm where our config files live
+add_filter('wpcfm_content_dir', function($var) { return $_SERVER['DOCUMENT_ROOT'] . '/private/config'; });
+add_filter('wpcfm_content_url', function($var) { return WP_HOME . '/private/config'; });

--- a/wp_cfm_import/alter_wpcfm_config_path.php
+++ b/wp_cfm_import/alter_wpcfm_config_path.php
@@ -9,5 +9,5 @@
 */
 
 // Tell wp-cfm where our config files live
-add_filter('wpcfm_content_dir', function($var) { return $_SERVER['DOCUMENT_ROOT'] . '/private/config'; });
-add_filter('wpcfm_content_url', function($var) { return WP_HOME . '/private/config'; });
+add_filter('wpcfm_config_dir', function($var) { return $_SERVER['DOCUMENT_ROOT'] . '/private/config'; });
+add_filter('wpcfm_config_url', function($var) { return WP_HOME . '/private/config'; });

--- a/wp_cfm_import/wp_cfm_after_clone.php
+++ b/wp_cfm_import/wp_cfm_after_clone.php
@@ -25,8 +25,8 @@ if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT !== 'live')) {
   # way to do that is to add a mu-plugin that uses the `wpcfm_content_dir`
   # directory filter to alter the path.  See the README.md for more details. 
   $config_map = [ 'test' => 'pantheon_test',
-									'dev'  => 'pantheon_dev',
-									'default' => 'pantheon_dev' ];
+		  'dev'  => 'pantheon_dev',
+		  'default' => 'pantheon_dev' ];
   $config_name = array_key_exists(PANTHEON_ENVIRONMENT, $config_map) ? $config_map[PANTHEON_ENVIRONMENT] : $config_map['default'];
  
   my_wp_cfm_runcmd("wp plugin activate wp-cfm 2>&1",

--- a/wp_cfm_import/wp_cfm_after_clone.php
+++ b/wp_cfm_import/wp_cfm_after_clone.php
@@ -1,0 +1,38 @@
+<?php
+function my_wp_cfm_runcmd($cmd, $msg) {
+  print("\n$msg\n");
+  print("Running command: $cmd\n");
+  exec($cmd, $output, $status);
+  print("Status: $status\n");
+  print("Output: ". implode("\n",$output));
+}
+
+// Don't ever run this on the live environment! 
+if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT !== 'live')) {
+
+  # For each Pantheon environment, define a mapping from the Pantheon
+  # environment name to a file stored in the wp-cfm configuration directory.
+  #
+  # The "default" environment will be used for any environment that isn't
+  # defined, so it should always be set.
+  #
+  # N.B.the actual filename in the wp-cfm configuration directory will
+  # have a .json extension
+  #
+  # N.B. the default location for the wp-cfm configuration directory is /config
+  # in the document root.  That doesn't make sense in the Pantheon context,
+  # because it will be browsable.  Better to store it in /private/config. One
+  # way to do that is to add a mu-plugin that uses the `wpcfm_content_dir`
+  # directory filter to alter the path.  See the README.md for more details. 
+  $config_map = [ 'test' => 'pantheon_test',
+									'dev'  => 'pantheon_dev',
+									'default' => 'pantheon_dev' ];
+  $config_name = array_key_exists(PANTHEON_ENVIRONMENT, $config_map) ? $config_map[PANTHEON_ENVIRONMENT] : $config_map['default'];
+ 
+  my_wp_cfm_runcmd("wp plugin activate wp-cfm 2>&1",
+         "Making sure that wp-cfm plugin is activated");
+  
+  my_wp_cfm_runcmd("wp config pull $config_name 2>&1",
+         "pulling config for $config_name");
+}
+


### PR DESCRIPTION
Use wp-cfm and it's wp-cli integration to automatically import settings after db-clone