### PR TITLE
Example that imports configuration changes from .yml files upon code deployments

### DIFF
--- a/drush_config_import/README.md
+++ b/drush_config_import/README.md
@@ -1,0 +1,31 @@
+# Configuration import #
+
+This example will show you how to integrate Drush commands into your Quicksilver operations, with the practical outcome of importing configuration changes from `.yml` files . You can use the method shown here to run any Drush command you like.
+
+Note that with the current `webphp` type operations, your timeout is limited to 120 seconds, so long-running operations should be avoided for now. 
+
+## Instructions ##
+
+Setting up this example is easy:
+
+1. Add the example `drush_config_import.php` script to the 'private/scripts/drush_config_import' directory of your code repository.
+2. Add a Quicksilver operation to your `pantheon.yml` to fire the script before a deploy.
+3. Test a deploy out!
+4. Note that automating this step may not be appropriate for all sites. Sites on which configuration is edited in the live environment may not want to automatically switch to configuration stored in files. For more information, see https://www.drupal.org/documentation/administer/config
+
+Optionally, you may want to use the `terminus workflows watch` command to get immediate debugging feedback.
+
+### Example `pantheon.yml` ###
+
+Here's an example of what your `pantheon.yml` would look like if this were the only Quicksilver operation you wanted to use:
+
+```yaml
+api_version: 1
+
+workflows:
+  deploy:
+    after:
+      - type: webphp
+        description: Import configuration from .yml files
+        script: private/scripts/drush_config_import/drush_config_import.php
+```

--- a/drush_config_import/drush_config_import.php
+++ b/drush_config_import/drush_config_import.php
@@ -1,0 +1,9 @@
+<?php
+// Import all config changes.
+echo "Importing configuration from yml files...\n";
+passthru('drush config-import -y');
+echo "Import of configuration complete.\n";
+//Clear all cache
+echo "Clearing cache.\n";
+passthru('drush cc all');
+echo "Clearing cache complete.\n";


### PR DESCRIPTION
This example fulfills #59. Testing this site requires a Drupal 8 site. if you want a fresh site to test with, try copying these commands:

```bash

RAND_SITE=$(date |md5 | head -c12)
echo "Creating a site named: $RAND_SITE"
terminus sites create --site=$RAND_SITE --label=$RAND_SITE --upstream="Drupal 8"
terminus drush --site=$RAND_SITE --env=dev 'si -y'
echo 'sleeping so that the commit is not attempted before the file change is picked up.'  
sleep 10 
terminus site --site=$RAND_SITE   code commit --env=dev --message="Installing drupal"
terminus site init-env --site=$RAND_SITE --env=test
terminus site init-env --site=$RAND_SITE --env=live
```

To test this PR use the following steps. The terminus commands below assume that a site name is being set using a `.env` file rather than using a `--site` param.

* First add `drush_config_import.php` to a Drupal 8 site as you would any other Quicksilver script.
* Deploy that addition to test and live so that the script is run on future pushes to those environments.
* Double check that the `dev` environment has the latest database from `live`: `terminus site clone-content  --from-env=live  --to-env=dev  --db-only --yes`
* Verify that the `dev` environment is in sftp mode: `terminus  site  set-connection-mode --env=dev --mode=sftp`
* Export the configuration from the `dev` environment: `terminus drush --env=dev 'config-export -y'`
* Commit the result on the `dev` environment: `terminus site code commit --env=dev --message="Export of all config"`
* Deploy to `test`: `terminus site deploy --env=test  --note='Initial export of all config'`
* Deploy to `live`: `terminus site deploy --env=live  --note='Initial export of all config'`
* Here is where the testing really starts. Make a new role on the `dev` environment: `terminus drush --env=dev 'role-create qstest'`
* See the result of that operation: `terminus drush --env=dev 'role-list'`
* Export the config on the `dev` environment: `terminus drush --env=dev 'config-export -y'`
* Commit the change: `terminus site code commit --env=dev --message="Role added through drush for config testing"`
* Deploy to `test`: `terminus site deploy --env=test  --note='Config change made in dev. Should be auto-imported on test environment.'`
* Verify that the `test` environment now has the new role.: `terminus drush --env=test 'role-list'`
* Deploy to `live`: `terminus site deploy --env=live  --note='Config change made in dev. Should be auto-imported on live environment.'`
* Verify that the `live` environment now has the new role.: `terminus drush --env=live 'role-list'`

If you don't want to do all of that copying and pasting individually you can copy it all at once:

```bash

terminus site clone-content --from-env=live --to-env=dev --db-only --yes
terminus site set-connection-mode --env=dev --mode=sftp
terminus drush --env=dev 'config-export -y'
echo 'sleeping so that the commit is not attempted before the file change is picked up.'  
sleep 10 
terminus site code commit --env=dev --message="Export of all config"
terminus site deploy --env=test --note='Initial export of all config'
terminus site deploy --env=live --note='Initial export of all config'

terminus drush --env=dev 'role-create qstest'  
terminus drush --env=dev 'role-list'  
terminus drush --env=dev 'config-export -y' 
echo 'sleeping so that the commit is not attempted before the file change is picked up.'  
sleep 10 
terminus site code commit --env=dev --message="Role added through drush for config testing"  
terminus site deploy --env=test --note='Config change made in dev. Should be auto-imported on test environment.'  
terminus drush --env=test 'role-list'   
terminus site deploy --env=live --note='Config change made in dev. Should be auto-imported on live environment.'   
terminus drush --env=live 'role-list' 

```