### PR TITLE
Adding an example for generating development content on DB clones

### DIFF
--- a/example.pantheon.yml
+++ b/example.pantheon.yml
@@ -10,7 +10,7 @@ workflows:
         description: post to slack after each code pushed
         script: private/scripts/slack_after_code_push.php
 
-  # Database Clones: Notify, sanitize, and notify on db clone
+  # Database Clones: Notify, sanitize, generate content, and notify on db clone
   clone_database:
     before:
       - type: webphp
@@ -20,6 +20,9 @@ workflows:
       - type: webphp
         description: sanitize the db after each database Clone
         script: private/scripts/sanitize_after_db_clone.php
+      - type: webphp
+        description: generate development article content after the database clones 
+        script: private/scripts/generate_dev_content.php
       - type: webphp
         description: post to slack after the database clones
         script: private/scripts/slack_after_db_clone.php

--- a/generate_dev_content/README.md
+++ b/generate_dev_content/README.md
@@ -1,0 +1,29 @@
+# Automagically Generate Development Content #
+
+This example will show you how to integrate drush devel generate commands into your quicksilver operations, with the practical outcome of generating development content on each DB clone operation. You can use the method shown here to genereate content of any content type you want.
+
+## Instructions ##
+
+Setting up this example is easy:
+
+1. Add the example `generate_dev_content.php` script to the 'private/scripts/' directory of your code repository.
+2. Add a Quicksilver operation to your `pantheon.yml` to fire the script before a deploy.
+3. Test a deploy out!
+
+Optionally, you may want to use the `terminus workflows watch` command to get immediate debugging feedback.
+
+### Example `pantheon.yml` ###
+
+Here's an example of what your `pantheon.yml` would look like if this were the only Quicksilver operation you wanted to use:
+
+```yaml
+api_version: 1
+
+workflows:
+  clone_database:
+    after:
+      - type: webphp
+        description: enerate development article content after the database clones
+        script: private/scripts/generate_dev_content.php
+```
+

--- a/generate_dev_content/generate_dev_content.php
+++ b/generate_dev_content/generate_dev_content.php
@@ -1,0 +1,41 @@
+<?php
+
+// Generating Developer Content for "Article" Content Type
+
+// Only run this operation for development or multidev environments
+if (isset($_POST['environment']) && !in_array($_POST['environment'], array('test', 'live'))) {
+
+  // Only run this operation if Devel and Devel Generate modules are available. 
+  // Enable the modules if they are not already enabled
+  $modules = json_decode(shell_exec('drush pm-list --format=json'));
+  if (isset($modules->devel) && isset($modules->devel_generate)) {
+
+    if (isset($modules->devel) && $modules->devel->status !== 'Enabled') {
+      passthru('drush pm-enable -y devel');
+    }
+    if (isset($modules->devel_generate) && $modules->devel_generate->status !== 'Enabled') {
+      passthru('drush pm-enable -y devel_generate');
+    }
+
+    // Remove the existing production article content
+    echo "Removing production article content...\n";
+    passthru('drush genc --kill --types=article 0 0');
+    echo "Removal complete.\n";
+
+    // Generate new development article content
+    echo "Generating development article content...\n";
+    passthru('drush generate-content 20 --types=article');
+    echo "Generation complete.\n";
+
+    // Disable the Devel and Devel Generate modules as appropriate
+    if (isset($modules->devel) && $modules->devel->status !== 'Enabled') {
+      passthru('drush pm-disable -y devel');
+    }
+    if (isset($modules->devel_generate) && $modules->devel_generate->status !== 'Enabled') {
+      passthru('drush pm-disable -y devel_generate');
+    }
+  }
+  else {
+    echo "The Devel and Devel Generate modules must be present for this operation to work";
+  }
+}


### PR DESCRIPTION
Here is an example for generating development "article" content on DB clone operations. This is useful if your live site has only a few pieces of content (i.e. an initial blog post), but you need lots of extra content for development purposes.