### PR TITLE
Example to automatically import config on each deploy using Drupal 8's CM

### DIFF
--- a/example.pantheon.yml
+++ b/example.pantheon.yml
@@ -24,7 +24,7 @@ workflows:
         description: post to slack after the database clones
         script: private/scripts/slack_after_db_clone.php
   
-  # Code Deploys: Notify, Sanitize (if on test), post to new relic, update db, and notify completion
+  # Code Deploys: Notify, Sanitize (if on test), post to new relic, import config, update db, and notify completion
   deploy:
     before:
       - type: webphp
@@ -37,6 +37,9 @@ workflows:
       - type: webphp
         description: sanitize the db after deploy to test
         script: private/scripts/sanitize_after_db_clone.php
+      - type: webphp
+        description: import config into Drupal 8 site
+        script: private/scripts/import_config_d8.php
       - type: webphp
         description: pull configuration into the database
         script: private/scripts/config_pull_after_deploy.php

--- a/import_config_d8/README.md
+++ b/import_config_d8/README.md
@@ -1,0 +1,30 @@
+# Automagically Import Config in D8 #
+
+This example will show you how to automatically import config on each deploy using Drupal 8's configuration management system. 
+
+## Instructions ##
+
+Setting up this example is easy:
+
+1. Add the example `import_config_d8.php` script to the 'private/scripts/' directory of your code repository.
+2. Add a Quicksilver operation to your `pantheon.yml` to fire the script before a deploy.
+3. Test a deploy out!
+
+Optionally, you may want to use the `terminus workflows watch` command to get immediate debugging feedback.
+
+### Example `pantheon.yml` ###
+
+Here's an example of what your `pantheon.yml` would look like if this were the only Quicksilver operation you wanted to use:
+
+```yaml
+api_version: 1
+
+workflows:
+  deploy:
+    after:
+      - type: webphp
+        description: import config into Drupal 8 site
+        script: private/scripts/import_config_d8.php
+```
+
+

--- a/import_config_d8/import_config_d8.php
+++ b/import_config_d8/import_config_d8.php
@@ -1,0 +1,3 @@
+<?php
+
+// Automagically import config into your D8 site upon code deployment

--- a/import_config_d8/import_config_d8.php
+++ b/import_config_d8/import_config_d8.php
@@ -1,3 +1,7 @@
 <?php
 
 // Automagically import config into your D8 site upon code deployment
+
+echo "Importing configuration...\n";
+passthru('drush config-import -y');
+echo "Importing configuration complete.\n";


### PR DESCRIPTION
This example will show you how to automatically import config on each deploy using Drupal 8's configuration management system.