### PR TITLE
Slack Notify with Drush Site Audit on Deploy

### DIFF
--- a/slack_notification/slack_notification.php
+++ b/slack_notification/slack_notification.php
@@ -53,6 +53,9 @@ switch($_POST['wf_type']) {
     $deploy_tag = `git describe --tags`;
     $deploy_message = $_POST['deploy_message'];
 
+    // Set a Slack Attachments title
+    $title = 'Deploying :rocket:';
+
     // Prepare the slack payload as per:
     // https://api.slack.com/incoming-webhooks
     $text = 'Deploy to the '. $_ENV['PANTHEON_ENVIRONMENT'];
@@ -75,6 +78,9 @@ switch($_POST['wf_type']) {
     $email = `git log -1 --pretty=%ce`;
     $message = `git log -1 --pretty=%B`;
     $hash = `git log -1 --pretty=%h`;
+
+    // Set a Slack Attachments title
+    $title = 'Syncing code :fax:';
 
     // Prepare the slack payload as per:
     // https://api.slack.com/incoming-webhooks
@@ -104,7 +110,7 @@ switch($_POST['wf_type']) {
 
 $attachment = array(
   'fallback' => $text,
-  'title' => 'Deploying :rocket:',
+  'title' => $title,
   'color' => $pantheon_yellow, // Can either be one of 'good', 'warning', 'danger', or any hex color code
   'fields' => $fields
 );

--- a/slack_notification/slack_notification.php
+++ b/slack_notification/slack_notification.php
@@ -104,7 +104,7 @@ switch($_POST['wf_type']) {
 
 $attachment = array(
   'fallback' => $text,
-  'pretext' => 'Deploying :rocket:',
+  'title' => 'Deploying :rocket:',
   'color' => $pantheon_yellow, // Can either be one of 'good', 'warning', 'danger', or any hex color code
   'fields' => $fields
 );

--- a/slack_notification/slack_notify_drush_site_audit.php
+++ b/slack_notification/slack_notify_drush_site_audit.php
@@ -1,0 +1,133 @@
+<?php
+
+// Run a Drush Site Audit in case someone made a boo boo on Deploy
+// @TODO: Duplicate to Hipchat
+ob_start();
+passthru('drush aa --strict=0'); // Run the drush command for site audit
+$site_audit_all = ob_get_contents();
+ob_end_clean();
+
+// Important constants :)
+$pantheon_yellow = '#EFD01B';
+
+// Default values for parameters
+$defaults = array(
+  'slack_channel' => '#quicksilver',
+  'slack_username' => 'Pantheon-Quicksilver',
+  'always_show_text' => false,
+);
+
+// Load our hidden credentials.
+// See the README.md for instructions on storing secrets.
+$secrets = _get_secrets(array('slack_url'), $defaults);
+
+// Build an array of fields to be rendered with Slack Attachments as a table
+// attachment-style formatting:
+// https://api.slack.com/docs/attachments
+$fields = array(
+  array(
+    'title' => 'Site',
+    'value' => $_ENV['PANTHEON_SITE_NAME'],
+    'short' => 'true'
+  ),
+  array( // Render Environment name with link to site, <http://{ENV}-{SITENAME}.pantheon.io|{ENV}>
+    'title' => 'Environment',
+    'value' => '<http://' . $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . '.pantheonsite.io|' . $_ENV['PANTHEON_ENVIRONMENT'] . '>',
+    'short' => 'true'
+  ),
+  array( // Render Name with link to Email from Commit message
+    'title' => 'By',
+    'value' => $_POST['user_email'],
+    'short' => 'true'
+  ),
+  array( // Render workflow phase that the message was sent
+    'title' => 'Workflow',
+    'value' => ucfirst($_POST['stage']) . ' ' . str_replace('_', ' ',  $_POST['wf_type']),
+    'short' => 'true'
+  ),
+  array(
+    'title' => 'View Dashboard',
+    'value' => '<https://dashboard.pantheon.io/sites/'. PANTHEON_SITE .'#'. PANTHEON_ENVIRONMENT .'/deploys|View Dashboard>',
+    'short' => 'true'
+  ),
+);
+
+// Set a Slack Attachments title
+$title = 'Post-Deploy Site Audit :helmet_with_white_cross:';
+
+// Prepare the slack payload as per:
+// https://api.slack.com/incoming-webhooks
+$text = 'Site Audit Report after deployment to the *'. $_ENV['PANTHEON_ENVIRONMENT'];
+$text .= ' environment of '. $_ENV['PANTHEON_SITE_NAME'] .' by '. $_POST['user_email'] .' complete!';
+$text .= ' <https://dashboard.pantheon.io/sites/'. PANTHEON_SITE .'#'. PANTHEON_ENVIRONMENT .'/deploys|View Dashboard>';
+$text .= "\n\n*SITE AUDIT REPORT*: \n\n$site_audit_all";
+// No need to render Site Audit All as a slack attachment,
+// full report is cut off due to character limit
+
+$attachment = array(
+  'fallback' => $text,
+  'title' => $title,
+  'color' => $pantheon_yellow, // Can either be one of 'good', 'warning', 'danger', or any hex color code
+  'fields' => $fields,
+  'text' => $site_audit_all
+);
+
+_slack_notification($secrets['slack_url'], $secrets['slack_channel'], $secrets['slack_username'], $text, $attachment, $secrets['always_show_text']);
+
+
+/**
+ * Get secrets from secrets file.
+ *
+ * @param array $requiredKeys  List of keys in secrets file that must exist.
+ */
+function _get_secrets($requiredKeys, $defaults)
+{
+  $secretsFile = $_SERVER['HOME'] . '/files/private/secrets.json';
+  if (!file_exists($secretsFile)) {
+    die('No secrets file found. Aborting!');
+  }
+  $secretsContents = file_get_contents($secretsFile);
+  $secrets = json_decode($secretsContents, 1);
+  if ($secrets == FALSE) {
+    die('Could not parse json in secrets file. Aborting!');
+  }
+  $secrets += $defaults;
+  $missing = array_diff($requiredKeys, array_keys($secrets));
+  if (!empty($missing)) {
+    die('Missing required keys in json secrets file: ' . implode(',', $missing) . '. Aborting!');
+  }
+  return $secrets;
+}
+
+/**
+ * Send a notification to slack
+ */
+function _slack_notification($slack_url, $channel, $username, $text, $attachment, $alwaysShowText = false)
+{
+  $attachment['fallback'] = $text;
+  $post = array(
+    'username' => $username,
+    'channel' => $channel,
+    'icon_emoji' => ':lightning_cloud:',
+    'attachments' => array($attachment)
+  );
+  if ($alwaysShowText) {
+    $post['text'] = $text;
+  }
+  $payload = json_encode($post);
+  $ch = curl_init();
+  curl_setopt($ch, CURLOPT_URL, $slack_url);
+  curl_setopt($ch, CURLOPT_POST, 1);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+  curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+  curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+  curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+  // Watch for messages with `terminus workflows watch --site=SITENAME`
+  print("\n==== Posting to Slack ====\n");
+  $result = curl_exec($ch);
+  print("RESULT: $result");
+  // $payload_pretty = json_encode($post,JSON_PRETTY_PRINT); // Uncomment to debug JSON
+  // print("JSON: $payload_pretty"); // Uncomment to Debug JSON
+  print("\n===== Post Complete! =====\n");
+  curl_close($ch);
+}


### PR DESCRIPTION
Drush Site Audit on deploy.

![image](https://cloud.githubusercontent.com/assets/3300713/15239172/288954d2-1895-11e6-98aa-2231119a21b5.png)

* @TODO: Duplicate to HipChat
* This is implemented as a separate script, didn't want to assume everyone would ALWAYS want to run the site audit. Also this report is quite verbose, so I think people should opt-in if they want to pollute their Slack channel.
* This is grouped under /slack_notification example, but could be arguably moved to it's own example as drush_site_audit or something similar. Concern there is duplicating Slack notification markup further. Building this makes me think a slack_helper.php would be easier to include basic functionality across multiple scripts/quicksilver workflow tasks. It looks like this was recently considered in combine-slack branch and deemed unnecessary when slack_lib.inc was merged into the main file. Perhaps this is cause to reconsider.

PS - Thanks to conversation with @JessiFischer this week at DrupalCon—this seemed worthwhile to implement & make sure no mistakes were made post-deploy for some of our sites.
