### PR TITLE
Fixed incorrect $failed URL check count

### DIFF
--- a/url_checker/url_checker.php
+++ b/url_checker/url_checker.php
@@ -83,7 +83,7 @@ function url_checker_build_output($results, $failed) {
   foreach ($results as $item) {
     $output .= '  ' . $item['status'] . ' - ' . $item['url'] . "\n";
   }
-  $output .= "--------\n" . count($failed) . " failed\n\n";
+  $output .= "--------\n" . $failed . " failed\n\n";
   return $output;
 }
 


### PR DESCRIPTION
count() method used on top of the $failed variable which is already a valid numeric value.