### PR TITLE
Corrected variable name syntax error

### DIFF
--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -52,7 +52,7 @@ elseif ($_POST['wf_type'] == 'deploy') {
   // Find out if there's a deploy tag:
   $revision = `git describe --tags`;
   // Get the annotation:
-  $changelog = `git tag -l -n99 $deploy_tag`;
+  $changelog = `git tag -l -n99 $revision`;
   $user = $_POST['user_email'];
 }
 


### PR DESCRIPTION
The variable $deploy_tag was changed to $revision in all places but one. I changed the remaining old name to the new name: $revision.