### PR TITLE
Fix undefined variable in new_relic_deploy

### DIFF
--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -52,7 +52,7 @@ elseif ($_POST['wf_type'] == 'deploy') {
   // Find out if there's a deploy tag:
   $revision = `git describe --tags`;
   // Get the annotation:
-  $changelog = `git tag -l -n99 $deploy_tag`;
+  $changelog = `git tag -l -n99 $revision`;
   $user = $_POST['user_email'];
 }
 


### PR DESCRIPTION
Rename undefined $deploy_tag to $revision from line 53.