### PR TITLE
Import all wp-cfm config files in private/scripts

### DIFF
--- a/wp_cfm_import/README.md
+++ b/wp_cfm_import/README.md
@@ -28,7 +28,7 @@ Just copy it to `wp-config/mu-plugins`.
    
 ### Creating a WP-CFM configuration file
 
-This should be straight forward, but you need to know which _wp_options_ values you should track.  If you don't know, one way to
+This should be straight forward, but you need to know which `wp_options` values you should track.  If you don't know, one way to
 find out is this:
 
 1. Put your site into sftp mode.
@@ -43,10 +43,8 @@ find out is this:
 
 ### Automating loading the WP-CFM configuration file
 
-You can have as many or as few configurations as you like.  In `wp_cfm_after_clone.php` change the values in `$config_map` to
-set the mapping between environments and filenames.  Follow the instructions in the comments.
-
-Now we just need to configure our pantheon.yml to actually do the import, triggered after the `db_clone` workflow:
+You can have as many or as few configurations as you like.
+Now we just need to configure our pantheon.yml to actually do the import, triggered after the `db_clone` and `deploy` workflows:
 
 ```
 ---
@@ -58,6 +56,12 @@ workflows:
   clone_database:
     after:
       - type: webphp
-        description: Pull environment specific config using wp-cfm after cloning db
+        description: Import configuration with WP-CFM after cloning a database
+        script: private/scripts/wp_cfm_after_clone.php
+
+  deploy:
+    after:
+      - type: webphp
+        description: Import configuration with WP-CFM after deployment
         script: private/scripts/wp_cfm_after_clone.php
 ```

--- a/wp_cfm_import/wp_cfm_after_clone.php
+++ b/wp_cfm_import/wp_cfm_after_clone.php
@@ -1,38 +1,35 @@
 <?php
-function my_wp_cfm_runcmd($cmd, $msg) {
-  print("\n$msg\n");
-  print("Running command: $cmd\n");
-  exec($cmd, $output, $status);
-  print("Status: $status\n");
-  print("Output: ". implode("\n",$output));
+print( "\n==== WP-CFM Config Import Starting ====\n" );
+// Activate the wp-cfm plugin
+exec( 'wp plugin activate wp-cfm 2>&1' );
+
+// Automagically import config into WP-CFM site upon code deployment
+$path  = $_SERVER['DOCUMENT_ROOT'] . '/private/config';
+$files = scandir( $path );
+$files = array_diff( scandir( $path ), array( '.', '..' ) );
+
+// Import all config .json files in private/config
+foreach( $files as $file ){
+
+	$file_parts = pathinfo($file);
+
+	if( $file_parts['extension'] != 'json' ){
+		continue;
+	}
+
+	exec( 'wp config pull ' . $file_parts['filename'] . ' 2>&1', $output );
+
+	if ( count( $output ) > 0 ) {
+		$output = preg_replace( '/\s+/', ' ', array_slice( $output, 1, - 1 ) );
+		$output = str_replace( ' update', ' [update]', $output );
+		$output = str_replace( ' create', ' [create]', $output );
+		$output = str_replace( ' delete', ' [delete]', $output );
+		$output = implode( $output, "\n" );
+		$output = rtrim( $output );
+	}
 }
 
-// Don't ever run this on the live environment! 
-if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT !== 'live')) {
+// Flush the cache
+exec( 'wp cache flush' );
 
-  # For each Pantheon environment, define a mapping from the Pantheon
-  # environment name to a file stored in the wp-cfm configuration directory.
-  #
-  # The "default" environment will be used for any environment that isn't
-  # defined, so it should always be set.
-  #
-  # N.B.the actual filename in the wp-cfm configuration directory will
-  # have a .json extension
-  #
-  # N.B. the default location for the wp-cfm configuration directory is /config
-  # in the document root.  That doesn't make sense in the Pantheon context,
-  # because it will be browsable.  Better to store it in /private/config. One
-  # way to do that is to add a mu-plugin that uses the `wpcfm_content_dir`
-  # directory filter to alter the path.  See the README.md for more details. 
-  $config_map = [ 'test' => 'pantheon_test',
-		  'dev'  => 'pantheon_dev',
-		  'default' => 'pantheon_dev' ];
-  $config_name = array_key_exists(PANTHEON_ENVIRONMENT, $config_map) ? $config_map[PANTHEON_ENVIRONMENT] : $config_map['default'];
- 
-  my_wp_cfm_runcmd("wp plugin activate wp-cfm 2>&1",
-         "Making sure that wp-cfm plugin is activated");
-  
-  my_wp_cfm_runcmd("wp config pull $config_name 2>&1",
-         "pulling config for $config_name");
-}
-
+print( "\n==== WP-CFM Config Import Complete ====\n" );


### PR DESCRIPTION
Having to edit the PHP file each time you add new config is cumbersome. This pull request allows all json files in `private/config` to be imported automatically. Import happens on deploy as well as database clone.