### PR TITLE
Updating the db-sanitization example to use drush

### DIFF
--- a/db_sanitization/db_sanitization_drupal.php
+++ b/db_sanitization/db_sanitization_drupal.php
@@ -2,10 +2,9 @@
 // Don't ever santize the database on the live environment. Doing so would
 // destroy the canonical version of the data.
 if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT !== 'live')) {
-  // Bootstrap Drupal using the same technique as is in index.php.
-  define('DRUPAL_ROOT', $_SERVER['DOCUMENT_ROOT']);
-  require_once DRUPAL_ROOT . '/includes/bootstrap.inc';
-  drupal_bootstrap(DRUPAL_BOOTSTRAP_DATABASE);
-  // From http://crackingdrupal.com/blog/greggles/creating-sanitized-drupal-database-dump#comment-164
-  db_query("UPDATE users SET mail = CONCAT(name, '@localhost'), init = CONCAT(name, '@localhost'), pass = MD5(CONCAT('MILDSECRET', name));");
+
+	// Import all config changes.
+	echo "Sanitizing the database...\n";
+	passthru('drush sql-sanitize -y');
+	echo "Database sanitization complete.\n";
 }


### PR DESCRIPTION
The previous example bootstrapped D7. It was inflexible and needing to be updated to D8, so I asked @greg-1-anderson . He suggested a pull request to use Drush sql-sanitize instead. 