### PR TITLE
Use short format when retrieving the latest git tag.

### DIFF
--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -50,7 +50,7 @@ elseif ($_POST['wf_type'] == 'deploy') {
   // Topline description:
   $description = 'Deploy to environment triggered via Pantheon';
   // Find out if there's a deploy tag:
-  $revision = `git describe --tags`;
+  $revision = `git describe --tags --abbrev=0`;
   // Get the annotation:
   $changelog = `git tag -l -n99 $revision`;
   $user = $_POST['user_email'];


### PR DESCRIPTION
`git describe --tags` outputs the latest tag but in long format. According to [the docs](https://git-scm.com/docs/git-describe) we can use `--abbrev=0` "to _suppress long format, only showing the closest tag_". This is important because `git tag` prefers the short name.

Closes #124.