### PR TITLE
Adding the wp_search_replace example

### DIFF
--- a/wp_search_replace/README.md
+++ b/wp_search_replace/README.md
@@ -1,0 +1,29 @@
+# Search and Replace URLs on WordPress Sites #
+
+This example will show you how you can automatically find and replace URLs in the database on a WordPress website. This practice can help smooth out workflow gotchas with sites that have multiple domains in an environment.
+
+## Instructions ##
+
+Setting up this example is easy:
+
+1. Add the wp_search_replace.php to the `private` directory of your code repository.
+2. Add a Quicksilver operation to your `pantheon.yml` to fire the script a deploy.
+3. Test a deploy out!
+
+Optionally, you may want to use the `terminus workflows watch` command to get immediate debugging feedback.
+
+### Example `pantheon.yml` ###
+
+Here's an example of what your `pantheon.yml` would look like if this were the only Quicksilver operation you wanted to use:
+
+```yaml
+
+api_version: 1
+
+workflows:
+  clone_database:
+    after:
+      - type: webphp
+        description: Search and replace url in database
+        script: private/scripts/search-replace-example.php
+```

--- a/wp_search_replace/wp_search_replace.php
+++ b/wp_search_replace/wp_search_replace.php
@@ -4,12 +4,12 @@ echo "Replacing previous environment urls with new environment urls... \n";
 if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
   switch( $_ENV['PANTHEON_ENVIRONMENT'] ) {
     case 'live':
-      passthru('wp search-replace "://test-example.pantheonsite.io" "://example.com"');
+      passthru('wp search-replace "://test-example.pantheonsite.io" "://example.com" --all-tables ');
       break;
     case 'test':
-      passthru('wp search-replace "://example1.pantheonsite.io" "://test-examplesite.pantheonsite.io"');
-      passthru('wp search-replace "://example2.pantheonsite.io" "://test-examplesite.pantheonsite.io"');
-      passthru('wp search-replace "://example3.pantheonsite.io" "://test-examplesite.pantheonsite.io"');
+      passthru('wp search-replace "://example1.pantheonsite.io" "://test-examplesite.pantheonsite.io" --all-tables ');
+      passthru('wp search-replace "://example2.pantheonsite.io" "://test-examplesite.pantheonsite.io" --all-tables ');
+      passthru('wp search-replace "://example3.pantheonsite.io" "://test-examplesite.pantheonsite.io" --all-tables ');
       break;
   }
 }

--- a/wp_search_replace/wp_search_replace.php
+++ b/wp_search_replace/wp_search_replace.php
@@ -1,0 +1,16 @@
+<?php
+echo "Replacing previous environment urls with new environment urls... \n";
+
+if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+  switch( $_ENV['PANTHEON_ENVIRONMENT'] ) {
+    case 'live':
+      passthru('wp search-replace "://test-example.pantheonsite.io" "://example.com"');
+      break;
+    case 'test':
+      passthru('wp search-replace "://example1.pantheonsite.io" "://test-examplesite.pantheonsite.io"');
+      passthru('wp search-replace "://example2.pantheonsite.io" "://test-examplesite.pantheonsite.io"');
+      passthru('wp search-replace "://example3.pantheonsite.io" "://test-examplesite.pantheonsite.io"');
+      break;
+  }
+}
+?>


### PR DESCRIPTION
This Quicksilver example adds automated wp search_replace on db clone in different environments.

This was originally brought up in @alexfornuto 's PR in Docs: [include quicksilver resolution to multiple DB find/replace #3960](https://github.com/pantheon-systems/documentation/pull/3960).