### PR TITLE
add wp_toggle_dev_plugins example

### DIFF
--- a/wp_toggle_dev_plugins/README.md
+++ b/wp_toggle_dev_plugins/README.md
@@ -1,0 +1,29 @@
+# Toggle Developer Plugins on WordPress Sites #
+
+This example will show how you can automatically activate and deactivate plugins based on environment on deploy.  This will ease development and potentially improve performance on Live.
+
+## Instructions ##
+
+Setting up this example is easy:
+
+1. Add the wp_toggle_dev_plugins.php to the `private/scripts` directory of your code repository.
+2. Add a Quicksilver operation to your `pantheon.yml` to fire the script a deploy.
+3. Test a deploy out!
+
+Optionally, you may want to use the `terminus workflow:watch` command to get immediate debugging feedback.
+
+### Example `pantheon.yml` ###
+
+Here's an example of what your `pantheon.yml` would look like if this were the only Quicksilver operation you wanted to use:
+
+```yaml
+api_version: 1
+
+workflows:
+  deploy:
+    after:
+      # Toggle developer plugins
+      - type: webphp 
+        description: Toggle developer plugins
+        script: private/scripts/wp_toggle_dev_plugins.php
+```

--- a/wp_toggle_dev_plugins/wp_toggle_dev_plugins.php
+++ b/wp_toggle_dev_plugins/wp_toggle_dev_plugins.php
@@ -1,0 +1,20 @@
+<?php
+// hello is our example plugin, swap out with the slug of your plugin of choice
+echo "Toggle developer plugins: checking environment... \n";
+if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+  switch( $_ENV['PANTHEON_ENVIRONMENT'] ) {
+    case 'live':
+      echo "Toggle developer plugins: Live, deactivating plugins... \n";
+      passthru('wp plugin deactivate hello ');
+      break;
+    case 'test':
+      echo "Toggle developer plugins: Test, activating plugins... \n";
+      passthru('wp plugin activate hello ');
+      break;
+    case 'dev':
+      echo "Toggle developer plugins: Dev, activating plugins... \n";
+      passthru('wp plugin activate hello ');
+      break; 
+  }
+}
+?>


### PR DESCRIPTION
This example will show how you can automatically activate and deactivate plugins based on environment on deploy.  This will ease development and potentially improve performance on Live.