### PR TITLE
Add example to disable config_readonly module on database clone to dev

### DIFF
--- a/drush_reset_modules_after_clone/drush_reset_modules_after_clone.php
+++ b/drush_reset_modules_after_clone/drush_reset_modules_after_clone.php
@@ -1,0 +1,22 @@
+
+<?php
+/**
+ * This uninstalls the configuration read-only module when a database is cloned to a dev environment.
+ * if you don't uninstall the module, your config will be read-only on a dev site after a clone from live or test
+ *
+ * This script should be instructed to run after the clone_database operation in pantheon.yml
+ */
+// The clone_database may be triggered on any environment, but we only want
+// to automatically disable the configuration read-only module when this event happens in a dev
+// or multidev environment.
+if (isset($_POST['environment']) && !in_array($_POST['environment'], array('test', 'live'))) {
+  // Retrieve a list of modules with drush pm-list.
+  // shell_exec() will return the output of an executable as a string.
+  // Pass the --format=json flag into the drush command so the output can be converted into an array with json_decode().
+  $modules = json_decode(shell_exec('drush pm-list --format=json'));
+  // uninstall config_readonly if it is installed and enabled.
+  if (isset($modules->config_readonly) && $modules->config_readonly->status == 'Enabled') {
+    // This time let's just passthru() to run the drush command so the command output prints to the workflow log.
+    passthru('drush pm-uninstall -y config_readonly');
+  }
+}

--- a/drush_reset_modules_after_clone/readme.md
+++ b/drush_reset_modules_after_clone/readme.md
@@ -1,0 +1,33 @@
+# Reset Modules After Clone #
+
+The script disables the [config_readonly](https://www.drupal.org/project/config_readonly) 
+module after a database has been cloned to a `dev` or `multidev` environment. 
+Purpose: when config_readonly is enabled in a live environment, the configuration can't be changed. 
+If the database is copied to a dev or multi-dev environment, the module is still enabled, and the dev/multi-dev site is set to read only. 
+If the site is read-only, you can't uninstall modules, and you are locked out and can't make edits to your site. 
+
+## Instructions ##
+
+- Be sure the [config_readonly](https://www.drupal.org/project/config_readonly) module is installed into your Drupal codebase.
+- Copy the `drush_reset_modules_after_clone` directory into the private/scripts directory of your code repository.
+- Add a Quicksilver operation to your pantheon.yml to fire the script after a `clone_database`.
+- Test a database clone to dev from an environment where the config_readonly module is enabled.
+
+Note: While Pantheon does not require a `settings.php` file to run Drupal, Drush does. Make sure you have one committed to the codebase.
+
+### Example `pantheon.yml` ###
+
+Here's an example of what your `pantheon.yml` would look like if this were the only Quicksilver operation you wanted to use:
+
+```yaml
+api_version: 1
+
+workflows:
+
+  # Database Clones
+  clone_database:
+    after:
+      - type: webphp
+        description: Reset modules per environment after database clone
+        script: private/scripts/drush_reset_modules_after_clone/drush_reset_modules_after_clone.php
+```


### PR DESCRIPTION
We ran into an issue on database clone from live > dev when the config_readonly module was enabled. It locked us out of the dev site - and we couldn't disable the module via the UI. This quicksilver example is what we have in place to uninstall the module when cloning the DB from a production environment. It's based on the existing drush_enable_devel example. Thought it might be helpful for someone else that's using the config_readonly module on their production environment.