### PR TITLE
Fix db sanitization typos

### DIFF
--- a/db_sanitization/db_sanitization_drupal.php
+++ b/db_sanitization/db_sanitization_drupal.php
@@ -3,7 +3,7 @@
 // destroy the canonical version of the data.
 if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT !== 'live')) {
 
-	// Import all config changes.
+	// Run the Drush command to sanitize the database.
 	echo "Sanitizing the database...\n";
 	passthru('drush sql-sanitize -y');
 	echo "Database sanitization complete.\n";

--- a/db_sanitization/db_sanitization_wordpress.php
+++ b/db_sanitization/db_sanitization_wordpress.php
@@ -2,10 +2,10 @@
 // Don't ever santize the database on the live environment. Doing so would
 // destroy the canonical version of the data.
 if (defined('PANTHEON_ENVIRONMENT') && (PANTHEON_ENVIRONMENT !== 'live')) {
-  // Bootstrap Drupal using the same code as is in index.php.
 
+  // Bootstrap WordPress.
   require_once $_SERVER['DOCUMENT_ROOT'] . '/wp-load.php';
   global $wpdb;
-  // Adapted from rom http://crackingdrupal.com/blog/greggles/creating-sanitized-drupal-database-dump#comment-164
+  // Query the database to set all user's email addresses to username@localhost.
   $wpdb->query("UPDATE wp_users SET user_email = CONCAT(user_login, '@localhost'), user_pass = MD5(CONCAT('MILDSECRET', user_login)), user_activation_key = '';");
 }


### PR DESCRIPTION
This PR fixes two different typos in comments within both the WordPress and Drupal db_sanitization examples.