### PR TITLE
Adding information about the Quicksilver Pushback project

### DIFF
--- a/quicksilver_pushback/README.md
+++ b/quicksilver_pushback/README.md
@@ -1,0 +1,5 @@
+# Quicksilver Pushback #
+
+This Quicksilver project is used in conjunction with the various suite of [Terminus Build Tools](https://github.com/pantheon-systems/terminus-build-tools-plugin)-based example repositories to push any commits made on the Pantheon dashboard back to the original Git repository for the site. This allows developers (or other users) to work on the Pantheon dashboard in SFTP mode and commit their code, through Pantheon, back to the canonical upstream repository via a PR. This is especially useful in scenarios where you want to export configuration (Drupal, WP-CFM).
+
+This project is maintained in it's own repo located at https://github.com/pantheon-systems/quicksilver-pushback. Check that page for more information about the project, including installation instructions. Please note that it comes installed automatically if you use the Terminus Build Tools plugin, so you probably don't need to install it yourself unless you're following a non-standard workflow.


### PR DESCRIPTION
The Quicksilver Pushback project is an example that I've referenced in Office Hours and training that allows code to be pushed back from Pantheon to the external git repo that it originated from. I always look in the Quicksilver Examples repo, but it's managed in its own repo so that it's able to be pulled in as a dependency. 

This PR adds a folder + readme for this project, but rather than providing the code for the project, it just links to the existing project: https://github.com/pantheon-systems/quicksilver-pushback