### PR TITLE
Account for wf_type sync_code_with_build for IC sites

### DIFF
--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -30,7 +30,7 @@ if ($nr == false) {
 // have good deploy markers, we gather data differently depending
 // on the context.
 
-if ($_POST['wf_type'] == 'sync_code') {
+if (in_array($_POST['wf_type'], ['sync_code','sync_code_with_build'])) {  
   // commit 'subject'
   $description = trim(`git log --pretty=format:"%s" -1`);
   $revision = trim(`git log --pretty=format:"%h" -1`);


### PR DESCRIPTION
Some variables are left undefined if the site is leveraging integrated composer.  Adding wf_type sync_code_with_build to address.