### PR TITLE
Cleans up git output for NR API post

### DIFF
--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -50,7 +50,7 @@ elseif ($_POST['wf_type'] == 'deploy') {
 
 // clean up the git output
 $revision = rtrim($revision, "\n");
-$changelog = rtrim($revision, "\n");
+$changelog = rtrim($changelog, "\n");
 
 $deployment_data = [
   "deployment" => [

--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -51,6 +51,7 @@ elseif ($_POST['wf_type'] == 'deploy') {
 // clean up the git output
 $revision = rtrim($revision, "\n");
 $changelog = rtrim($changelog, "\n");
+$changelog = str_replace('\'','',$changelog);
 
 $deployment_data = [
   "deployment" => [

--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -48,6 +48,10 @@ elseif ($_POST['wf_type'] == 'deploy') {
   $user = $_POST['user_email'];
 }
 
+// clean up the git output
+$revision = rtrim($revision, "\n");
+$changelog = rtrim($revision, "\n");
+
 $deployment_data = [
   "deployment" => [
     "revision" => $revision,


### PR DESCRIPTION
Fixes a 'bad request' error from the New Relic API, which was causing markers to not be stored in test and live env's (although dev was working) - see support ticket: 929345

The Pantheon internal process that processes the workflow to the test and live env's was using the tag and git commit text for revision and changelog in the demo, which was adding a \n to the end of the git output and apostrophes inline, and causing the deployment markers to be denied by the API

A simple rtrim and replacing apostrophes fixes it, and allows the marker to be created successfully.