### PR TITLE
NR deployment markers - account for merging multidevs and default required variables

### DIFF
--- a/new_relic_deploy/new_relic_deploy.php
+++ b/new_relic_deploy/new_relic_deploy.php
@@ -27,7 +27,13 @@ if (empty($app_guid)) {
 // have good deploy markers, we gather data differently depending
 // on the context.
 
-if (in_array($_POST['wf_type'], ['sync_code','sync_code_with_build'])) {
+// Default required variables
+$user = "bot@getpantheon.com";
+$description = 'Deploy to environment triggered via Pantheon';
+$revision = 'unknown';
+$changelog = 'Pantheon Automation';
+
+if (in_array($_POST['wf_type'], ['sync_code','sync_code_with_build','merge_cloud_development_environment_into_dev'])) {
   // commit 'subject'
   $description = trim(`git log --pretty=format:"%s" -1`);
   $revision = trim(`git log --pretty=format:"%h" -1`);


### PR DESCRIPTION
The existing code would not capture deployment markers when merging multidevs into master (ie: Autopilot), and threw some errors for unset variables. This PR defaults the required variables and captures the merge_cloud_development_environment_into_dev workflow type