### PR TITLE
Update cloudflare_cache to reflect latest standards

### DIFF
--- a/cloudflare_cache/README.md
+++ b/cloudflare_cache/README.md
@@ -4,9 +4,9 @@ This example demonstrates how to purge Cloudflare cache when your live environme
 
 ## Instructions ##
 
-- Copy `cloudflare_cache.json` to `files/private` of the *live* environment after updating it with your cloudflare info.
+- Copy `cloudflare_cache.json` to `files/private` of the `live` environment after updating it with your cloudflare info.
  - API key can be found in the `My Settings` page on the Cloudflare site.
- - I couldn't find zone id in the UI. I viewed page source on the overview page and found it printed in JavaScript.
+ - The ZONE ID can be found in your [selected domain's sidebar panel](https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/)
 - Add the example `cloudflare_cache.php` script to the `private/scripts` directory of your code repository.
 - Add a Quicksilver operation to your `pantheon.yml` to fire the script after a deploy.
 - Deploy through to the live environment and clear the cache!

--- a/cloudflare_cache/cloudflare_cache.json
+++ b/cloudflare_cache/cloudflare_cache.json
@@ -1,5 +1,4 @@
 {
   "zone_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-  "api_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-  "email": "cloudflare.user@example.com"
+  "auth_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 }

--- a/cloudflare_cache/cloudflare_cache.php
+++ b/cloudflare_cache/cloudflare_cache.php
@@ -22,9 +22,7 @@ function purge_cache($config) {
   curl_setopt($ch, CURLOPT_URL, 'https://api.cloudflare.com/client/v4/zones/' . $config['zone_id'] . '/purge_cache');
   curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
   curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-    'X-Auth-Email: ' . $config['email'],
-    'X-Auth-Key: ' . $config['api_key'],
-    'Content-Type: application/json'
+    'Authorization: Bearer ' . $config['auth_token']
   ));
   curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
   print("\n==== Sending Request to Cloudflare ====\n");


### PR DESCRIPTION
The previous version no longer worked for user-based authentication. The new method for API calls is to use tokens, which are generated in the user's personal account or the cloudflare account API tokens manager. Lastly, documentation has been updated to reflect changes along with adding clarity around how users can find their zone id.

Side note: This quicksilver function should be ported over to the pantheon cache plugin as an enableable option and two configuration fields: zone id and api token.