### PR TITLE
chore: add DevRel as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pantheon-systems/developer-experience
+* @pantheon-systems/developer-experience @pantheon-systems/devrel


### PR DESCRIPTION
## Summary
- Adds @pantheon-systems/devrel as a codeowner alongside @pantheon-systems/developer-experience
- Per Greg and Chris request in the DELENG-391 ownership thread